### PR TITLE
HBASE-24538: Simplify the lifecycle of mini cluster

### DIFF
--- a/include/hbase/test-util/test-util.h
+++ b/include/hbase/test-util/test-util.h
@@ -37,11 +37,6 @@ class TestUtil {
   TestUtil();
 
   /**
-   * Destroying a TestUtil will spin down a cluster and remove the test dir.
-   */
-  ~TestUtil();
-
-  /**
    * Create a random string. This random string is all letters, as such it is
    * very good for use as a directory name.
    */

--- a/src/hbase/test-util/test-util.cc
+++ b/src/hbase/test-util/test-util.cc
@@ -46,13 +46,6 @@ std::string TestUtil::RandString(int len) {
 
 TestUtil::TestUtil() : temp_dir_(TestUtil::RandString()) {}
 
-TestUtil::~TestUtil() {
-  if (mini_) {
-    StopMiniCluster();
-    mini_ = nullptr;
-  }
-}
-
 void TestUtil::StartMiniCluster(int32_t num_region_servers) {
   mini_ = std::make_unique<MiniCluster>();
   mini_->StartCluster(num_region_servers);


### PR DESCRIPTION
Cleans up unnecessary methods and moves the teardown of the mini cluster
to the d'tor so that an explicit cleanup is not needed. It is not prone
to the deadlocks mentioned in the jira anymore.