### PR TITLE
HBASE-24559: Fix test logging initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,13 +159,15 @@ if (DOWNLOAD_DEPENDENCIES)
   download_zookeeper(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 endif(DOWNLOAD_DEPENDENCIES)
 
+set(BOOST_MIN_VERSION "1.6.1")
+
 # ensure we have required dependencies
 find_package(Threads)
-find_package(Boost REQUIRED COMPONENTS context thread system filesystem regex)
+find_package(Boost ${BOOST_MIN_VERSION} REQUIRED COMPONENTS context thread system filesystem regex)
 find_package(LibEvent REQUIRED)
 find_package(Gflags REQUIRED)
 if (DOWNLOAD_DEPENDENCIES)
-	find_package(Sodium REQUIRED)
+  find_package(Sodium REQUIRED)
 endif(DOWNLOAD_DEPENDENCIES)
 find_package(Folly REQUIRED)
 find_package(Krb5 REQUIRED)

--- a/include/hbase/test-util/mini-cluster-util.h
+++ b/include/hbase/test-util/mini-cluster-util.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+#include <folly/Random.h>
+#include <folly/experimental/TestUtil.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+#include "hbase/client/configuration.h"
+#include "hbase/test-util/mini-cluster.h"
+
+namespace hbase {
+/**
+ * @brief Class to deal with a local instance cluster for testing.
+ */
+class MiniClusterUtility {
+ public:
+  MiniClusterUtility();
+
+  /**
+   * Create a random string. This random string is all letters, as such it is
+   * very good for use as a directory name.
+   */
+  static std::string RandString(int len = 32);
+
+  /**
+   * Returns the configuration to talk to the local cluster
+   */
+  std::shared_ptr<Configuration> conf() const { return conf_; }
+
+  /**
+   * Starts mini hbase cluster with specified number of region servers
+   */
+  void StartMiniCluster(int32_t num_region_servers);
+
+  void StopMiniCluster();
+  void CreateTable(const std::string &table, const std::string &family);
+  void CreateTable(const std::string &table, const std::vector<std::string> &families);
+  void CreateTable(const std::string &table, const std::string &family,
+                   const std::vector<std::string> &keys);
+  void CreateTable(const std::string &table, const std::vector<std::string> &families,
+                   const std::vector<std::string> &keys);
+
+  void StartStandAloneInstance();
+  void StopStandAloneInstance();
+  void RunShellCmd(const std::string &);
+  void MoveRegion(const std::string &region, const std::string &server);
+
+ private:
+  std::unique_ptr<MiniCluster> mini_;
+  folly::test::TemporaryDirectory temp_dir_;
+  std::shared_ptr<Configuration> conf_ = std::make_shared<Configuration>();
+};
+}  // namespace hbase

--- a/include/hbase/test-util/test-util.h
+++ b/include/hbase/test-util/test-util.h
@@ -18,56 +18,18 @@
  */
 #pragma once
 
-#include <folly/Random.h>
-#include <folly/experimental/TestUtil.h>
-
-#include <cstdlib>
-#include <memory>
-#include <string>
-#include <vector>
-#include "hbase/client/configuration.h"
-#include "hbase/test-util/mini-cluster.h"
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
 
 namespace hbase {
-/**
- * @brief Class to deal with a local instance cluster for testing.
- */
-class TestUtil {
- public:
-  TestUtil();
-
-  /**
-   * Create a random string. This random string is all letters, as such it is
-   * very good for use as a directory name.
-   */
-  static std::string RandString(int len = 32);
-
-  /**
-   * Returns the configuration to talk to the local cluster
-   */
-  std::shared_ptr<Configuration> conf() const { return conf_; }
-
-  /**
-   * Starts mini hbase cluster with specified number of region servers
-   */
-  void StartMiniCluster(int32_t num_region_servers);
-
-  void StopMiniCluster();
-  void CreateTable(const std::string &table, const std::string &family);
-  void CreateTable(const std::string &table, const std::vector<std::string> &families);
-  void CreateTable(const std::string &table, const std::string &family,
-                   const std::vector<std::string> &keys);
-  void CreateTable(const std::string &table, const std::vector<std::string> &families,
-                   const std::vector<std::string> &keys);
-
-  void StartStandAloneInstance();
-  void StopStandAloneInstance();
-  void RunShellCmd(const std::string &);
-  void MoveRegion(const std::string &region, const std::string &server);
-
- private:
-  std::unique_ptr<MiniCluster> mini_;
-  folly::test::TemporaryDirectory temp_dir_;
-  std::shared_ptr<Configuration> conf_ = std::make_shared<Configuration>();
-};
-}  // namespace hbase
+// main() function intended to be used in tests. This initializes the needed gflags/glog libraries as needed.
+#define HBASE_TEST_MAIN() \
+  int main(int argc, char** argv) { \
+    ::testing::InitGoogleTest(&argc, argv); \
+    gflags::ParseCommandLineFlags(&argc, &argv, true);\
+    google::InstallFailureSignalHandler();\
+    google::InitGoogleLogging(argv[0]);\
+    return RUN_ALL_TESTS(); \
+  }
+} // namespace hbase

--- a/src/hbase/test-util/mini-cluster-util.cc
+++ b/src/hbase/test-util/mini-cluster-util.cc
@@ -17,17 +17,17 @@
  *
  */
 
-#include "hbase/test-util/test-util.h"
+#include "hbase/test-util/mini-cluster-util.h"
 #include <string.h>
 
 #include <folly/Format.h>
 
 #include "hbase/client/zk-util.h"
 
-using hbase::TestUtil;
+using hbase::MiniClusterUtility;
 using folly::Random;
 
-std::string TestUtil::RandString(int len) {
+std::string MiniClusterUtility::RandString(int len) {
   // Create the whole string.
   // Filling everything with z's
   auto s = std::string(len, 'z');
@@ -44,9 +44,9 @@ std::string TestUtil::RandString(int len) {
   return s;
 }
 
-TestUtil::TestUtil() : temp_dir_(TestUtil::RandString()) {}
+MiniClusterUtility::MiniClusterUtility() : temp_dir_(MiniClusterUtility::RandString()) {}
 
-void TestUtil::StartMiniCluster(int32_t num_region_servers) {
+void MiniClusterUtility::StartMiniCluster(int32_t num_region_servers) {
   mini_ = std::make_unique<MiniCluster>();
   mini_->StartCluster(num_region_servers);
 
@@ -55,43 +55,43 @@ void TestUtil::StartMiniCluster(int32_t num_region_servers) {
               mini_->GetConfValue(ZKUtil::kHBaseZookeeperClientPort_));
 }
 
-void TestUtil::StopMiniCluster() { mini_->StopCluster(); }
+void MiniClusterUtility::StopMiniCluster() { mini_->StopCluster(); }
 
-void TestUtil::CreateTable(const std::string &table, const std::string &family) {
+void MiniClusterUtility::CreateTable(const std::string &table, const std::string &family) {
   mini_->CreateTable(table, family);
 }
 
-void TestUtil::CreateTable(const std::string &table, const std::vector<std::string> &families) {
+void MiniClusterUtility::CreateTable(const std::string &table, const std::vector<std::string> &families) {
   mini_->CreateTable(table, families);
 }
 
-void TestUtil::CreateTable(const std::string &table, const std::string &family,
-                           const std::vector<std::string> &keys) {
+void MiniClusterUtility::CreateTable(const std::string &table, const std::string &family,
+                                     const std::vector<std::string> &keys) {
   mini_->CreateTable(table, family, keys);
 }
 
-void TestUtil::CreateTable(const std::string &table, const std::vector<std::string> &families,
-                           const std::vector<std::string> &keys) {
+void MiniClusterUtility::CreateTable(const std::string &table, const std::vector<std::string> &families,
+                                     const std::vector<std::string> &keys) {
   mini_->CreateTable(table, families, keys);
 }
 
-void TestUtil::MoveRegion(const std::string &region, const std::string &server) {
+void MiniClusterUtility::MoveRegion(const std::string &region, const std::string &server) {
   mini_->MoveRegion(region, server);
 }
 
-void TestUtil::StartStandAloneInstance() {
+void MiniClusterUtility::StartStandAloneInstance() {
   auto p = temp_dir_.path().string();
   auto cmd = std::string{"bin/start-local-hbase.sh " + p};
   auto res_code = std::system(cmd.c_str());
   CHECK_EQ(res_code, 0);
 }
 
-void TestUtil::StopStandAloneInstance() {
+void MiniClusterUtility::StopStandAloneInstance() {
   auto res_code = std::system("bin/stop-local-hbase.sh");
   CHECK_EQ(res_code, 0);
 }
 
-void TestUtil::RunShellCmd(const std::string &command) {
+void MiniClusterUtility::RunShellCmd(const std::string &command) {
   auto cmd_string = folly::sformat("echo \"{}\" | ../bin/hbase shell", command);
   auto res_code = std::system(cmd_string.c_str());
   CHECK_EQ(res_code, 0);

--- a/src/test/append-test.cc
+++ b/src/test/append-test.cc
@@ -17,11 +17,11 @@
  *
  */
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 
 #include "hbase/client/append.h"
 #include "hbase/client/mutation.h"
 #include "hbase/utils/time-util.h"
+#include "hbase/test-util/test-util.h"
 
 using hbase::Append;
 using hbase::Cell;
@@ -103,3 +103,5 @@ TEST(Append, Add) {
   EXPECT_EQ(2, append.FamilyMap().size());
   EXPECT_EQ(1, append.FamilyMap().at("family-2").size());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/async-batch-rpc-retrying-test.cc
+++ b/src/test/async-batch-rpc-retrying-test.cc
@@ -22,7 +22,6 @@
 #include <folly/futures/Future.h>
 #include <folly/io/async/EventBase.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
-#include <gtest/gtest.h>
 #include <wangle/concurrent/IOThreadPoolExecutor.h>
 
 #include <chrono>
@@ -39,6 +38,7 @@
 #include "hbase/client/region-location.h"
 #include "hbase/client/result.h"
 #include "hbase/exceptions/exception.h"
+#include "hbase/test-util/mini-cluster-util.h"
 #include "hbase/test-util/test-util.h"
 #include "hbase/utils/time-util.h"
 
@@ -67,12 +67,11 @@ using folly::exception_wrapper;
 
 class AsyncBatchRpcRetryTest : public ::testing::Test {
  public:
-  static std::unique_ptr<hbase::TestUtil> test_util;
+  static std::unique_ptr<hbase::MiniClusterUtility> test_util;
   static std::string tableName;
 
   static void SetUpTestCase() {
-    google::InstallFailureSignalHandler();
-    test_util = std::make_unique<hbase::TestUtil>();
+    test_util = std::make_unique<hbase::MiniClusterUtility>();
     test_util->StartMiniCluster(2);
     std::vector<std::string> keys{"test0",   "test100", "test200", "test300", "test400",
                                   "test500", "test600", "test700", "test800", "test900"};
@@ -80,7 +79,7 @@ class AsyncBatchRpcRetryTest : public ::testing::Test {
     test_util->CreateTable(tableName, "d", keys);
   }
 };
-std::unique_ptr<hbase::TestUtil> AsyncBatchRpcRetryTest::test_util = nullptr;
+std::unique_ptr<hbase::MiniClusterUtility> AsyncBatchRpcRetryTest::test_util = nullptr;
 std::string AsyncBatchRpcRetryTest::tableName;
 
 class AsyncRegionLocatorBase : public AsyncRegionLocator {
@@ -575,3 +574,5 @@ TEST_F(AsyncBatchRpcRetryTest, PutsFailWithOperationTimeout) {
  std::make_shared<MockFailingAsyncRegionLocator>(6));
  EXPECT_ANY_THROW(runMultiGets(region_locator, "table12", true, 5, 100, 1000));
  }
+
+ HBASE_TEST_MAIN()

--- a/src/test/async-rpc-retrying-test.cc
+++ b/src/test/async-rpc-retrying-test.cc
@@ -46,7 +46,7 @@
 #include "hbase/exceptions/exception.h"
 #include "client/Client.pb.h"
 #include "HBase.pb.h"
-#include "hbase/test-util/test-util.h"
+#include "hbase/test-util/mini-cluster-util.h"
 #include "hbase/utils/time-util.h"
 
 using hbase::AsyncRpcRetryingCallerFactory;
@@ -78,15 +78,15 @@ using folly::exception_wrapper;
 
 class AsyncRpcRetryTest : public ::testing::Test {
  public:
-  static std::unique_ptr<hbase::TestUtil> test_util;
+  static std::unique_ptr<hbase::MiniClusterUtility> test_util;
 
   static void SetUpTestCase() {
     google::InstallFailureSignalHandler();
-    test_util = std::make_unique<hbase::TestUtil>();
+    test_util = std::make_unique<hbase::MiniClusterUtility>();
     test_util->StartMiniCluster(2);
   }
 };
-std::unique_ptr<hbase::TestUtil> AsyncRpcRetryTest::test_util = nullptr;
+std::unique_ptr<hbase::MiniClusterUtility> AsyncRpcRetryTest::test_util = nullptr;
 
 class AsyncRegionLocatorBase : public AsyncRegionLocator {
  public:

--- a/src/test/bytes-util-test.cc
+++ b/src/test/bytes-util-test.cc
@@ -18,10 +18,10 @@
  */
 
 #include <folly/Logging.h>
-#include <gtest/gtest.h>
 #include <string>
 
 #include "hbase/utils/bytes-util.h"
+#include "hbase/test-util/test-util.h"
 
 using hbase::BytesUtil;
 
@@ -67,3 +67,5 @@ TEST(TestBytesUtil, TestCreateClosestRowAfter) {
 
   EXPECT_EQ("f\\x00", BytesUtil::ToStringBinary(BytesUtil::CreateClosestRowAfter("f")));
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/cell-test.cc
+++ b/src/test/cell-test.cc
@@ -20,8 +20,9 @@
 #include "hbase/client/cell.h"
 
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 #include <memory>
+
+#include "hbase/test-util/test-util.h"
 
 using hbase::Cell;
 using hbase::CellType;
@@ -193,3 +194,5 @@ TEST(CellTest, CellEstimatedSize) {
   EXPECT_EQ(cell4.EstimatedSize(), cell5.EstimatedSize());
   EXPECT_TRUE(cell6.EstimatedSize() >= cell1.EstimatedSize());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/client-deserializer-test.cc
+++ b/src/test/client-deserializer-test.cc
@@ -17,10 +17,10 @@
  *
  */
 #include <folly/io/IOBuf.h>
-#include <gtest/gtest.h>
 
 #include "client/Client.pb.h"
 #include "hbase/serde/rpc-serde.h"
+#include "hbase/test-util/test-util.h"
 
 using namespace hbase;
 using folly::IOBuf;
@@ -62,3 +62,5 @@ TEST(TestRpcSerde, TestGoodGetRequestFullRoundTrip) {
   ASSERT_GT(used_bytes, 0);
   ASSERT_EQ(used_bytes, buf->length());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/client-serializer-test.cc
+++ b/src/test/client-serializer-test.cc
@@ -16,8 +16,6 @@
  * limitations under the License.
  *
  */
-#include <gtest/gtest.h>
-
 #include <folly/io/Cursor.h>
 
 #include <string>
@@ -25,6 +23,7 @@
 #include "HBase.pb.h"
 #include "rpc/RPC.pb.h"
 #include "hbase/serde/rpc-serde.h"
+#include "hbase/test-util/test-util.h"
 
 using namespace hbase;
 using namespace hbase::pb;
@@ -73,3 +72,5 @@ TEST(RpcSerdeTest, TestHeaderDecode) {
   EXPECT_TRUE(h.ParseFromArray(header_buf->data(), header_buf->length()));
   EXPECT_EQ("elliott", h.user_info().effective_user());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/client-test.cc
+++ b/src/test/client-test.cc
@@ -17,8 +17,6 @@
  *
  */
 
-#include <gtest/gtest.h>
-
 #include <fstream>
 #include "hbase/client/append.h"
 #include "hbase/client/cell.h"
@@ -33,6 +31,7 @@
 #include "hbase/client/table.h"
 #include "hbase/exceptions/exception.h"
 #include "hbase/serde/table-name.h"
+#include "hbase/test-util/mini-cluster-util.h"
 #include "hbase/test-util/test-util.h"
 #include "hbase/utils/bytes-util.h"
 #include "hbase/utils/optional.h"
@@ -44,7 +43,7 @@ using hbase::RetriesExhaustedException;
 using hbase::none;
 using hbase::Put;
 using hbase::Table;
-using hbase::TestUtil;
+using hbase::MiniClusterUtility;
 
 class ClientTest : public ::testing::Test {
  protected:
@@ -93,15 +92,15 @@ class ClientTest : public ::testing::Test {
     // the hbase-site.xml would be persisted by MiniCluster
     setenv("HBASE_CONF", kDefHBaseConfPath, 1);
   }
-  static std::unique_ptr<hbase::TestUtil> test_util;
+  static std::unique_ptr<hbase::MiniClusterUtility> test_util;
 
   static void SetUpTestCase() {
     google::InstallFailureSignalHandler();
-    test_util = std::make_unique<hbase::TestUtil>();
+    test_util = std::make_unique<hbase::MiniClusterUtility>();
     test_util->StartMiniCluster(2);
   }
 };
-std::unique_ptr<hbase::TestUtil> ClientTest::test_util = nullptr;
+std::unique_ptr<hbase::MiniClusterUtility> ClientTest::test_util = nullptr;
 
 TEST_F(ClientTest, EmptyConfigurationPassedToClient) { ASSERT_ANY_THROW(hbase::Client client); }
 
@@ -701,3 +700,5 @@ TEST_F(ClientTest, MultiPutsWithRegionSplits) {
   table->Close();
   client.Close();
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/concurrent-map-test.cc
+++ b/src/test/concurrent-map-test.cc
@@ -18,9 +18,9 @@
  */
 
 #include <folly/Logging.h>
-#include <gtest/gtest.h>
 #include <string>
 
+#include "hbase/test-util/test-util.h"
 #include "hbase/utils/concurrent-map.h"
 
 using hbase::concurrent_map;
@@ -34,3 +34,5 @@ TEST(TestConcurrentMap, TestFindAndErase) {
 
   ASSERT_EQ(map.end(), map.find("foo"));
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/configuration-test.cc
+++ b/src/test/configuration-test.cc
@@ -18,7 +18,8 @@
  */
 
 #include "hbase/client/configuration.h"
-#include <gtest/gtest.h>
+
+#include "hbase/test-util/test-util.h"
 
 using hbase::Configuration;
 
@@ -117,3 +118,5 @@ TEST(Configuration, SetGetBoolBasic) {
   conf.SetInt("foo", true);
   EXPECT_EQ(conf.GetInt("foo", false), true);
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/delete-test.cc
+++ b/src/test/delete-test.cc
@@ -17,10 +17,10 @@
  *
  */
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 
 #include "hbase/client/delete.h"
 #include "hbase/client/mutation.h"
+#include "hbase/test-util/test-util.h"
 #include "hbase/utils/time-util.h"
 
 using hbase::Delete;
@@ -122,3 +122,5 @@ TEST(Delete, AddColumn) {
   auto &cell = del.FamilyMap().at(family)[2];
   EXPECT_EQ(ts, cell->Timestamp());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/exception-test.cc
+++ b/src/test/exception-test.cc
@@ -16,11 +16,11 @@
  * limitations under the License.
  *
  */
-#include <gtest/gtest.h>
 
 #include "hbase/exceptions/exception.h"
 
 #include "folly/ExceptionWrapper.h"
+#include "hbase/test-util/test-util.h"
 
 using hbase::ExceptionUtil;
 using hbase::IOException;
@@ -62,3 +62,5 @@ TEST(ExceptionUtilTest, RemoteExceptionShouldRetry) {
   ex.set_exception_class_name("org.apache.hadoop.hbase.UnknownRegionException");
   EXPECT_FALSE(ExceptionUtil::ShouldRetry(ex));
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/filter-test.cc
+++ b/src/test/filter-test.cc
@@ -17,7 +17,6 @@
  *
  */
 
-#include <gtest/gtest.h>
 #include "hbase/client/client.h"
 #include "hbase/client/configuration.h"
 #include "hbase/client/get.h"
@@ -27,6 +26,7 @@
 #include "client/Comparator.pb.h"
 #include "HBase.pb.h"
 #include "hbase/serde/table-name.h"
+#include "hbase/test-util/mini-cluster-util.h"
 #include "hbase/test-util/test-util.h"
 
 using hbase::Configuration;
@@ -34,7 +34,7 @@ using hbase::Get;
 using hbase::Put;
 using hbase::FilterFactory;
 using hbase::Table;
-using hbase::TestUtil;
+using hbase::MiniClusterUtility;
 using hbase::pb::CompareType;
 using hbase::ComparatorFactory;
 using hbase::Comparator;
@@ -42,7 +42,7 @@ using hbase::Comparator;
 class FilterTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    test_util_ = std::make_unique<TestUtil>();
+    test_util_ = std::make_unique<MiniClusterUtility>();
     test_util_->StartMiniCluster(2);
   }
 
@@ -51,10 +51,10 @@ class FilterTest : public ::testing::Test {
   virtual void SetUp() {}
   virtual void TearDown() {}
 
-  static std::unique_ptr<TestUtil> test_util_;
+  static std::unique_ptr<MiniClusterUtility> test_util_;
 };
 
-std::unique_ptr<TestUtil> FilterTest::test_util_ = nullptr;
+std::unique_ptr<MiniClusterUtility> FilterTest::test_util_ = nullptr;
 
 TEST_F(FilterTest, GetWithColumnPrefixFilter) {
   // write row1 with 3 columns (column_1, column_2, and foo_column)
@@ -139,3 +139,5 @@ TEST_F(FilterTest, GetWithQualifierFilter) {
   EXPECT_EQ("value2", *(result->Value("d", "b")));
   EXPECT_EQ("value3", *(result->Value("d", "c")));
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/get-test.cc
+++ b/src/test/get-test.cc
@@ -17,11 +17,11 @@
  *
  */
 
+#include <glog/logging.h>
+
 #include "hbase/client/get.h"
 #include "hbase/client/cell.h"
-
-#include <glog/logging.h>
-#include <gtest/gtest.h>
+#include "hbase/test-util/test-util.h"
 
 using hbase::Cell;
 using hbase::Get;
@@ -219,3 +219,5 @@ TEST(Get, Exception) {
   ASSERT_THROW(Get tmp = Get(row), std::runtime_error);
   ASSERT_THROW(Get tmp = Get(""), std::runtime_error);
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/hbase-configuration-test.cc
+++ b/src/test/hbase-configuration-test.cc
@@ -21,10 +21,10 @@
 #include <iostream>
 
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
 #include "hbase/client/configuration.h"
 #include "hbase/client/hbase-configuration-loader.h"
+#include "hbase/test-util/test-util.h"
 #include "hbase/utils/optional.h"
 
 using namespace hbase;
@@ -373,3 +373,5 @@ TEST(Configuration, GetBoolException) {
   ASSERT_TRUE(conf != none) << "No configuration object present.";
   ASSERT_THROW((*conf).GetBool("bool.exception", false), std::runtime_error);
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/increment-test.cc
+++ b/src/test/increment-test.cc
@@ -17,11 +17,11 @@
  *
  */
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 
 #include "hbase/client/increment.h"
 #include "hbase/client/mutation.h"
 #include "hbase/client/put.h"
+#include "hbase/test-util/test-util.h"
 #include "hbase/utils/time-util.h"
 
 using hbase::Increment;
@@ -127,3 +127,5 @@ TEST(Increment, AddColumn) {
   EXPECT_EQ(2, incr.FamilyMap().size());
   EXPECT_EQ(1, incr.FamilyMap().at("family-2").size());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/location-cache-retry-test.cc
+++ b/src/test/location-cache-retry-test.cc
@@ -17,8 +17,6 @@
  *
  */
 
-#include <gtest/gtest.h>
-
 #include "hbase/client/append.h"
 #include "hbase/client/cell.h"
 #include "hbase/client/client.h"
@@ -33,6 +31,7 @@
 #include "hbase/client/table.h"
 #include "hbase/exceptions/exception.h"
 #include "hbase/serde/table-name.h"
+#include "hbase/test-util/mini-cluster-util.h"
 #include "hbase/test-util/test-util.h"
 #include "hbase/utils/bytes-util.h"
 
@@ -43,22 +42,22 @@ using hbase::MetaUtil;
 using hbase::RetriesExhaustedException;
 using hbase::Put;
 using hbase::Table;
-using hbase::TestUtil;
+using hbase::MiniClusterUtility;
 
 using std::chrono_literals::operator"" s;
 
 class LocationCacheRetryTest : public ::testing::Test {
  public:
-  static std::unique_ptr<hbase::TestUtil> test_util;
+  static std::unique_ptr<hbase::MiniClusterUtility> test_util;
   static void SetUpTestCase() {
     google::InstallFailureSignalHandler();
-    test_util = std::make_unique<hbase::TestUtil>();
+    test_util = std::make_unique<hbase::MiniClusterUtility>();
     test_util->StartMiniCluster(2);
     test_util->conf()->SetInt("hbase.client.retries.number", 5);
   }
 };
 
-std::unique_ptr<hbase::TestUtil> LocationCacheRetryTest::test_util = nullptr;
+std::unique_ptr<hbase::MiniClusterUtility> LocationCacheRetryTest::test_util = nullptr;
 
 TEST_F(LocationCacheRetryTest, GetFromMetaTable) {
   auto tn = folly::to<hbase::pb::TableName>("hbase:meta");
@@ -110,3 +109,5 @@ TEST_F(LocationCacheRetryTest, PutGet) {
   EXPECT_EQ("test1", result->Row());
   EXPECT_EQ("value1", *(result->Value("d", "1")));
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/location-cache-test.cc
+++ b/src/test/location-cache-test.cc
@@ -19,13 +19,13 @@
 #include "hbase/client/location-cache.h"
 
 #include <folly/Memory.h>
-#include <gtest/gtest.h>
 
 #include <chrono>
 
 #include "hbase/client/keyvalue-codec.h"
 #include "hbase/if/HBase.pb.h"
 #include "hbase/serde/table-name.h"
+#include "hbase/test-util/mini-cluster-util.h"
 #include "hbase/test-util/test-util.h"
 
 using hbase::Cell;
@@ -33,7 +33,7 @@ using hbase::Configuration;
 using hbase::ConnectionPool;
 using hbase::MetaUtil;
 using hbase::LocationCache;
-using hbase::TestUtil;
+using hbase::MiniClusterUtility;
 using hbase::KeyValueCodec;
 using std::chrono::milliseconds;
 
@@ -41,7 +41,7 @@ class LocationCacheTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
     google::InstallFailureSignalHandler();
-    test_util_ = std::make_unique<TestUtil>();
+    test_util_ = std::make_unique<MiniClusterUtility>();
     test_util_->StartMiniCluster(2);
   }
   static void TearDownTestCase() { test_util_.release(); }
@@ -50,10 +50,10 @@ class LocationCacheTest : public ::testing::Test {
   virtual void TearDown() {}
 
  public:
-  static std::unique_ptr<TestUtil> test_util_;
+  static std::unique_ptr<MiniClusterUtility> test_util_;
 };
 
-std::unique_ptr<TestUtil> LocationCacheTest::test_util_ = nullptr;
+std::unique_ptr<MiniClusterUtility> LocationCacheTest::test_util_ = nullptr;
 
 TEST_F(LocationCacheTest, TestGetMetaNodeContents) {
   auto cpu = std::make_shared<wangle::CPUThreadPoolExecutor>(4);
@@ -162,3 +162,5 @@ TEST_F(LocationCacheTest, TestCaching) {
   cpu->stop();
   io->stop();
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/put-test.cc
+++ b/src/test/put-test.cc
@@ -17,10 +17,10 @@
  *
  */
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 
 #include "hbase/client/mutation.h"
 #include "hbase/client/put.h"
+#include "hbase/test-util/test-util.h"
 #include "hbase/utils/time-util.h"
 
 using hbase::Put;
@@ -133,3 +133,5 @@ TEST(Put, AddColumn) {
   auto &cell = put.FamilyMap().at(family)[2];
   EXPECT_EQ(ts, cell->Timestamp());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/region-info-deserializer-test.cc
+++ b/src/test/region-info-deserializer-test.cc
@@ -19,12 +19,11 @@
 
 #include "hbase/serde/region-info.h"
 
-#include <gtest/gtest.h>
-
 #include <string>
 
 #include "hbase/if/HBase.pb.h"
 #include "hbase/serde/table-name.h"
+#include "hbase/test-util/test-util.h"
 
 using std::string;
 using hbase::pb::RegionInfo;
@@ -51,3 +50,5 @@ TEST(TestRegionInfoDesializer, TestDeserialize) {
 
   EXPECT_EQ(region_id, out.region_id());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/request-converter-test.cc
+++ b/src/test/request-converter-test.cc
@@ -19,11 +19,11 @@
 
 #include "hbase/client/request-converter.h"
 
-#include <gtest/gtest.h>
 #include <limits>
 #include "hbase/connection/request.h"
 #include "hbase/client/get.h"
 #include "hbase/client/scan.h"
+#include "hbase/test-util/test-util.h"
 
 using hbase::Get;
 using hbase::Scan;
@@ -124,3 +124,5 @@ TEST(RequestConverter, ToScan) {
   ASSERT_FALSE(msg->client_handles_heartbeats());
   ASSERT_FALSE(msg->track_scan_metrics());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/result-test.cc
+++ b/src/test/result-test.cc
@@ -18,7 +18,6 @@
  */
 
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 #include <limits>
 #include <memory>
 #include <string>
@@ -26,6 +25,7 @@
 
 #include "hbase/client/cell.h"
 #include "hbase/client/result.h"
+#include "hbase/test-util/test-util.h"
 #include "hbase/utils/optional.h"
 
 using hbase::Cell;
@@ -321,3 +321,5 @@ TEST(Result, ResultEstimatedSize) {
   LOG(INFO) << result1.EstimatedSize();
   LOG(INFO) << result2.EstimatedSize();
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/rpc-test.cc
+++ b/src/test/rpc-test.cc
@@ -28,7 +28,6 @@
 #include <folly/io/async/AsyncSocketException.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 #include <boost/thread.hpp>
 #include <chrono>
 
@@ -38,6 +37,7 @@
 #include "hbase/connection/rpc-test-server.h"
 #include "hbase/security/user.h"
 #include "hbase/serde/rpc-serde.h"
+#include "hbase/test-util/test-util.h"
 
 using namespace wangle;
 using namespace folly;
@@ -282,3 +282,5 @@ TEST_F(RpcTest, Pause) {
   server->stop();
   server->join();
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/scan-result-cache-test.cc
+++ b/src/test/scan-result-cache-test.cc
@@ -19,13 +19,13 @@
 
 #include <folly/Conv.h>
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 
 #include <vector>
 
 #include "hbase/client/cell.h"
 #include "hbase/client/result.h"
 #include "hbase/client/scan-result-cache.h"
+#include "hbase/test-util/test-util.h"
 
 using hbase::ScanResultCache;
 using hbase::Result;
@@ -175,3 +175,5 @@ TEST(ScanResultCacheTest, SizeOf) {
   LOG(INFO) << sizeof(f) << " " << f.capacity();
   LOG(INFO) << sizeof(foo) << " " << foo.capacity();
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/scan-test.cc
+++ b/src/test/scan-test.cc
@@ -17,10 +17,10 @@
  *
  */
 
-#include <gtest/gtest.h>
 #include <limits>
 
 #include "hbase/client/scan.h"
+#include "hbase/test-util/test-util.h"
 
 using hbase::Get;
 using hbase::Scan;
@@ -226,3 +226,5 @@ TEST(Scan, Exception) {
   ASSERT_THROW(Scan tmp(row), std::runtime_error);
   ASSERT_THROW(Scan tmp(""), std::runtime_error);
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/scanner-test.cc
+++ b/src/test/scanner-test.cc
@@ -18,7 +18,6 @@
  */
 
 #include <folly/Conv.h>
-#include <gtest/gtest.h>
 
 #include <chrono>
 #include <thread>
@@ -39,6 +38,7 @@
 #include "client/Comparator.pb.h"
 #include "client/Filter.pb.h"
 #include "hbase/serde/table-name.h"
+#include "hbase/test-util/mini-cluster-util.h"
 #include "hbase/test-util/test-util.h"
 #include "hbase/utils/time-util.h"
 
@@ -51,7 +51,7 @@ using hbase::Put;
 using hbase::Result;
 using hbase::Scan;
 using hbase::Table;
-using hbase::TestUtil;
+using hbase::MiniClusterUtility;
 using hbase::TimeUtil;
 using hbase::AsyncClientScanner;
 using hbase::AsyncTableResultScanner;
@@ -60,16 +60,16 @@ using hbase::pb::CompareType;
 
 class ScannerTest : public ::testing::Test {
  public:
-  static std::unique_ptr<hbase::TestUtil> test_util;
+  static std::unique_ptr<hbase::MiniClusterUtility> test_util;
   static const uint32_t num_rows;
 
   static void SetUpTestCase() {
     google::InstallFailureSignalHandler();
-    test_util = std::make_unique<hbase::TestUtil>();
+    test_util = std::make_unique<hbase::MiniClusterUtility>();
     test_util->StartMiniCluster(2);
   }
 };
-std::unique_ptr<hbase::TestUtil> ScannerTest::test_util = nullptr;
+std::unique_ptr<hbase::MiniClusterUtility> ScannerTest::test_util = nullptr;
 const uint32_t ScannerTest::num_rows = 1000;
 
 std::string Family(uint32_t i) { return "f" + folly::to<std::string>(i); }
@@ -366,3 +366,5 @@ TEST_F(ScannerTest, ScanNoResults) {
 
   TestScan(scan, 0, 0, table.get());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/server-name-test.cc
+++ b/src/test/server-name-test.cc
@@ -17,10 +17,10 @@
  *
  */
 
-#include "hbase/serde/server-name.h"
-
-#include <gtest/gtest.h>
 #include <string>
+
+#include "hbase/serde/server-name.h"
+#include "hbase/test-util/test-util.h"
 
 using hbase::pb::ServerName;
 
@@ -45,3 +45,5 @@ TEST(TestServerName, TestIPV6) {
   ASSERT_EQ("[::::1]", sn.host_name());
   ASSERT_EQ(123, sn.port());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/table-name-test.cc
+++ b/src/test/table-name-test.cc
@@ -18,11 +18,11 @@
  */
 
 #include <folly/Conv.h>
-#include <gtest/gtest.h>
 
 #include <string>
 
 #include "hbase/serde/table-name.h"
+#include "hbase/test-util/test-util.h"
 
 using namespace hbase;
 using hbase::pb::TableName;
@@ -52,3 +52,5 @@ TEST(TestTableName, TestToStringIncludeNS) {
   ASSERT_EQ(result.find("hbase"), 0);
   ASSERT_EQ("hbase:acl", result);
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/time-range-test.cc
+++ b/src/test/time-range-test.cc
@@ -18,9 +18,9 @@
  */
 
 #include "hbase/client/time-range.h"
+#include "hbase/test-util/test-util.h"
 
 #include <glog/logging.h>
-#include <gtest/gtest.h>
 
 using namespace hbase;
 
@@ -46,3 +46,5 @@ TEST(TimeRange, Exception) {
   // Min TS > Max TS
   ASSERT_THROW(TimeRange(10000, 2000), std::runtime_error);
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/user-util-test.cc
+++ b/src/test/user-util-test.cc
@@ -18,10 +18,10 @@
  */
 
 #include <folly/Logging.h>
-#include <gtest/gtest.h>
 #include <string>
 
 #include "hbase/utils/user-util.h"
+#include "hbase/test-util/test-util.h"
 
 using namespace std;
 using namespace hbase;
@@ -33,3 +33,5 @@ TEST(TestUserUtil, TestGetSomething) {
   // TODO shell out to whoami to check this.
   ASSERT_GT(name.length(), 0);
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/zk-deserializer-test.cc
+++ b/src/test/zk-deserializer-test.cc
@@ -22,9 +22,10 @@
 #include <folly/Logging.h>
 #include <folly/io/Cursor.h>
 #include <folly/io/IOBuf.h>
-#include <gtest/gtest.h>
 
 #include "server/zookeeper/ZooKeeper.pb.h"
+
+#include "hbase/test-util/test-util.h"
 
 using namespace hbase;
 using namespace hbase::pb;
@@ -121,3 +122,5 @@ TEST(TestZkDesializer, TestNoThrow) {
   ASSERT_TRUE(deser.Parse(buf.get(), &out));
   ASSERT_EQ(mrs.server().host_name(), out.server().host_name());
 }
+
+HBASE_TEST_MAIN()

--- a/src/test/zk-util-test.cc
+++ b/src/test/zk-util-test.cc
@@ -16,9 +16,8 @@
  * limitations under the License.
  *
  */
-#include <gtest/gtest.h>
-
 #include "hbase/client/zk-util.h"
+#include "hbase/test-util/test-util.h"
 
 using hbase::Configuration;
 using hbase::ZKUtil;
@@ -48,3 +47,5 @@ TEST(ZKUtilTest, MetaZNode) {
   conf.Set(ZKUtil::kHBaseZnodeParent_, "/hbase-secure");
   ASSERT_EQ("/hbase-secure/meta-region-server", ZKUtil::MetaZNode(conf));
 }
+
+HBASE_TEST_MAIN()


### PR DESCRIPTION
Split into two commits
    
1. Moved test-util/* to mini-cluster-util*
2. Implement a macro that is to be used by all tests. The macro adds
the initialization that can be exploited by all the unit tests
   
Ex: GLOG_logtostderr=1 ./async-batch-rpc-test...