### PR TITLE
HBASE-24642 (addendum): Do not run the container as root

### DIFF
--- a/bin/hbase-native-client-personality.sh
+++ b/bin/hbase-native-client-personality.sh
@@ -66,8 +66,6 @@ function docker_do_env_adds
 function personality_globals
 {
   # shellcheck disable=SC2034
-  SUDO_USER=root
-  # shellcheck disable=SC2034
   BUILD_NATIVE=true
   # shellcheck disable=SC2034
   BUILDTOOL=cmake

--- a/bin/jenkins/gather_machine_environment.sh
+++ b/bin/jenkins/gather_machine_environment.sh
@@ -49,6 +49,7 @@ cat /proc/diskstats >"${output}/diskstats" 2>&1 || true
 cat /sys/block/sda/stat >"${output}/sys-block-sda-stat" 2>&1 || true
 df -h >"${output}/df-h" 2>&1 || true
 ps -Aww >"${output}/ps-Aww" 2>&1 || true
+hostname -f >"${output}/fqdn-hostname" 2>&1 || true
 ifconfig -a >"${output}/ifconfig-a" 2>&1 || true
 lsblk -ta >"${output}/lsblk-ta" 2>&1 || true
 lsblk -fa >"${output}/lsblk-fa" 2>&1 || true


### PR DESCRIPTION
This pollutes the permissions of output artifacts thus affecting the
final cleanup. This can potentially fill up disks on jenkins machines.
Also adds some additional debugging information related to the env.